### PR TITLE
Update to Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
   "description": "PHP binding for v4 of the Cloudflare Client API.",
   "type": "library",
   "require": {
-    "guzzlehttp/guzzle": "^6.2.2",
-    "php": ">=7.0.0",
+    "guzzlehttp/guzzle": "^7.0.1",
+    "php": ">=7.2.5",
     "psr/http-message": "~1.0",
     "ext-json": "*"
   },


### PR DESCRIPTION
Updates library to use Guzzle 7 whilst we wait a few more months for Cloudflare to tag _their_ library (https://github.com/cloudflare/cloudflare-php/commit/7db3d6e62c7ab8fa29780354e8d370c49939cdec).